### PR TITLE
Allow to display login form on selected monitors only

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ Copy `/etc/nwg-hello/nwg-hello-default.json` to `/etc/nwg-hello/nwg-hello.json` 
     }
   ],
   "monitor_nums": [],
+  "form_on_monitors": [],
   "delay_secs": 1,
   "cmd-sleep": "systemctl suspend",
   "cmd-reboot": "systemctl reboot",
@@ -127,6 +128,7 @@ Copy `/etc/nwg-hello/nwg-hello-default.json` to `/etc/nwg-hello/nwg-hello.json` 
 - `"session_dirs"`: comma-separated paths to session directories. Modify only if you know well what you're doing.
 - `"custom_sessions"`: greetd can run whatever starts from the command line. This way we can add `bash`, `zsh` or something else here. The `"name"` field is the display name. The `"exec"` field is a command.
 - `"monitor_nums"`: leave as is to see the greeter on all monitors. Set e.g. `[0, 2]` for it to appear on the 1st and 3rd one.
+- `"form_on_monitors"`: which of above monitors to display the login form on (just the wallpaper on the rest).
 - `"delay_secs"`: some monitors take longer to turn on. In the meantime the greeter may behave oddly on other monitors. If it happens to restart/blink, increase this value. If you only have one monitor and no discrete GPU, you may probably set `0` here.
 - `"cmd-sleep"`, `"cmd-reboot"`, and `"cmd-poweroff"` are pre-defined for systemd-based systems. Use whatever works for you.
 - `"gtk-theme"`, `"gtk-icon-theme"` and `"gtk-cursor-theme"` are of little importance as long, as you use classes and IDs from the default css style sheet.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ worked pretty well. However, it brings QT dependencies, and my stuff is all GTK-
 framework, so couldn't adjust the greeter to my taste. The next choice was LightDM with [my modification](https://github.com/nwg-piotr/lightdm-nwg-greeter)
 of the [LightDM Elephant Greeter](https://github.com/max-moser/lightdm-elephant-greeter) by Maximilian Moser. It looked
 well, but LightDM would happen to hang way too often. Then I gave a try to greetd, and that was it. I only needed 
-a nice graphical greeter based on GTK3. Since there was no such thing, I had to develop my own.
+a nice graphical greeter based on GTK3. Since there was no such thing, I had to develop one.
 
 ## Features
 
@@ -37,6 +37,13 @@ a nice graphical greeter based on GTK3. Since there was no such thing, I had to 
 - gtk-layer-shell;
 - Hyprland or sway Wayland compositor;
 - gnome-themes-extra (recommended, as it provides us with the default Adwaita theme).
+
+## Make dependencies
+
+- python-build
+- python-installer
+- python-wheel
+- python-setuptools
 
 ## Installation
 

--- a/install.sh
+++ b/install.sh
@@ -16,4 +16,5 @@ install -Dm 644 -t "/usr/share/doc/nwg-hello" README.md
 
 # python3 setup.py install --optimize=1
 python -m build --wheel --no-isolation
+[ -f /usr/bin/nwg-hello ] && sudo rm /usr/bin/nwg-hello
 python -m installer dist/*.whl

--- a/install.sh
+++ b/install.sh
@@ -14,7 +14,6 @@ install -Dm644 -t /var/cache/nwg-hello cache.json -o greeter
 install -Dm 644 -t "/usr/share/licenses/nwg-hello" LICENSE
 install -Dm 644 -t "/usr/share/doc/nwg-hello" README.md
 
-# python3 setup.py install --optimize=1
 python -m build --wheel --no-isolation
 [ -f /usr/bin/nwg-hello ] && sudo rm /usr/bin/nwg-hello
 python -m installer dist/*.whl

--- a/install.sh
+++ b/install.sh
@@ -14,4 +14,6 @@ install -Dm644 -t /var/cache/nwg-hello cache.json -o greeter
 install -Dm 644 -t "/usr/share/licenses/nwg-hello" LICENSE
 install -Dm 644 -t "/usr/share/doc/nwg-hello" README.md
 
-python3 setup.py install --optimize=1
+# python3 setup.py install --optimize=1
+python -m build --wheel --no-isolation
+python -m installer dist/*.whl

--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+# Make sure you have 'python-build' 'python-installer' 'python-wheel' and 'python-setuptools' installed
+
 install -D -m 644 -t /etc/nwg-hello/ nwg-hello-default.json
 install -D -m 644 -t /etc/nwg-hello/ nwg-hello-default.css
 install -D -m 644 -t /etc/nwg-hello/ hyprland.conf

--- a/nwg-hello-default.json
+++ b/nwg-hello-default.json
@@ -10,6 +10,7 @@
     }
   ],
   "monitor_nums": [],
+  "form_on_monitors": [],
   "delay_secs": 1,
   "cmd-sleep": "systemctl suspend",
   "cmd-reboot": "systemctl reboot",

--- a/nwg_hello/main.py
+++ b/nwg_hello/main.py
@@ -66,6 +66,7 @@ defaults = {
     "template-name": "",
     "custom_sessions": [],
     "monitor_nums": [],
+    "form_on_monitors": [],
     "delay_secs": 1,
     "lang": "",
     "cmd-sleep": "systemctl suspend",
@@ -171,8 +172,11 @@ def main():
     for i in reversed(range(display.get_n_monitors())):
         if not settings["monitor_nums"] or i in settings["monitor_nums"]:
             monitor = display.get_monitor(i)
-            win = GreeterWindow(client, settings, sessions, x_sessions, users, monitor, voc, cache, args.log, args.test)
-            windows.append(win)
+            if not settings["form_on_monitors"] or i in settings["form_on_monitors"]:
+                win = GreeterWindow(client, settings, sessions, x_sessions, users, monitor, voc, cache, args.log, args.test)
+                windows.append(win)
+            else:
+                win = EmptyWindow(monitor, args.log, args.test)
 
     GLib.timeout_add(1, move_clock)
     Gtk.main()

--- a/nwg_hello/ui.py
+++ b/nwg_hello/ui.py
@@ -253,3 +253,34 @@ class GreeterWindow(Gtk.Window):
                 resp = greetd(self.client, jreq, log=self.log)
                 if "type" in resp and resp["type"] == "success":
                     sys.exit()
+
+
+class EmptyWindow(Gtk.Window):
+    def __init__(self, monitor, log, test):
+        eprint(f"Creating EmptyWindow on {monitor}", log=log)
+
+        self.test = test
+
+        Gtk.Window.__init__(self)
+
+        self.connect('destroy', Gtk.main_quit)
+        self.connect("key-release-event", self.handle_keyboard)
+
+        GtkLayerShell.init_for_window(self)
+        GtkLayerShell.set_monitor(self, monitor)
+        GtkLayerShell.set_layer(self, GtkLayerShell.Layer.OVERLAY)
+        GtkLayerShell.set_keyboard_mode(self, GtkLayerShell.KeyboardMode.ON_DEMAND)
+        GtkLayerShell.set_anchor(self, GtkLayerShell.Edge.TOP, True)
+        GtkLayerShell.set_anchor(self, GtkLayerShell.Edge.BOTTOM, True)
+        GtkLayerShell.set_anchor(self, GtkLayerShell.Edge.LEFT, True)
+        GtkLayerShell.set_anchor(self, GtkLayerShell.Edge.RIGHT, True)
+        GtkLayerShell.set_exclusive_zone(self, -1)
+
+        self.show()
+
+    def handle_keyboard(self, w, event):
+        if event.type == Gdk.EventType.KEY_RELEASE:
+            if self.test and event.keyval == Gdk.KEY_Escape:
+                Gtk.main_quit()
+
+        return True

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ def read(f_name):
 
 setup(
     name='nwg-hello',
-    version='0.2.0',
+    version='0.2.1',
     description='GTK3-based greeter for greetd',
     packages=find_packages(),
     include_package_data=True,


### PR DESCRIPTION
- Added the `"form_on_monitors"` config key, equal `[]` by default. Use a list, e.g. `[0, 1]` to specify which monitors to display the login form on. The rest will only display the wallpaper. Closes #12; the nwg-hello-default.json file looks like this from now on:

```json
{
  "session_dirs": [
    "/usr/share/wayland-sessions",
    "/usr/share/xsessions"
  ],
  "custom_sessions": [
    {
      "name": "Shell",
      "exec": "/usr/bin/bash"
    }
  ],
  "monitor_nums": [],
  "form_on_monitors": [],
  "delay_secs": 1,
  "cmd-sleep": "systemctl suspend",
  "cmd-reboot": "systemctl reboot",
  "cmd-poweroff": "systemctl poweroff",
  "gtk-theme": "Adwaita",
  "gtk-icon-theme": "",
  "gtk-cursor-theme": "",
  "prefer-dark-theme": true,
  "template-name": "",
  "lang": "",
  "env-vars": []
}
```
- the `install.sh` script changed, in order not to use `setup.py` any longer. Make sure you have 'python-build', 'python-installer', 'python-wheel' and 'python-setuptools' installed.