### PR TITLE
Emulate mouse button release event on startup

### DIFF
--- a/nwg_hello/main.py
+++ b/nwg_hello/main.py
@@ -131,11 +131,27 @@ if args.debug:
     eprint(f"X11 sessions: {x_sessions}", log=args.log)
 
 
+def set_clock():
+    _now = datetime.now()
+    for win in windows:
+        win.update_time(_now)
+    return False
+
+
 def move_clock():
     _now = datetime.now()
     for win in windows:
         win.update_time(_now)
     return True
+
+
+def emulate_mouse_event():
+    # In order to focus the window -> password form entry, we need to perform some mouse event.
+    # Although I tried hard, nothing worked well on Hyprland 0.43.0, so we'll only do it for sway.
+    if os.getenv('SWAYSOCK'):
+        subprocess.Popen("swaymsg seat - cursor release button1", shell=True)
+
+    return False
 
 
 def main():
@@ -178,7 +194,11 @@ def main():
             else:
                 win = EmptyWindow(monitor, args.log, args.test)
 
-    GLib.timeout_add(1, move_clock)
+    GLib.timeout_add(0, set_clock)
+    GLib.timeout_add(500, move_clock)
+
+    GLib.timeout_add(1000, emulate_mouse_event)
+
     Gtk.main()
 
 

--- a/nwg_hello/ui.py
+++ b/nwg_hello/ui.py
@@ -150,7 +150,7 @@ class GreeterWindow(Gtk.Window):
         GtkLayerShell.init_for_window(self.window)
         GtkLayerShell.set_monitor(self.window, monitor)
         GtkLayerShell.set_layer(self.window, GtkLayerShell.Layer.OVERLAY)
-        GtkLayerShell.set_keyboard_mode(self.window, GtkLayerShell.KeyboardMode.ON_DEMAND)
+        GtkLayerShell.set_keyboard_mode(self.window, GtkLayerShell.KeyboardMode.EXCLUSIVE)
         GtkLayerShell.set_anchor(self.window, GtkLayerShell.Edge.TOP, True)
         GtkLayerShell.set_anchor(self.window, GtkLayerShell.Edge.BOTTOM, True)
         GtkLayerShell.set_anchor(self.window, GtkLayerShell.Edge.LEFT, True)


### PR DESCRIPTION
This is a workaround that should resolve #20, but only if you use sway as the compositor. I failed finding a working solution on Hyprland 0.43.0. The 0.42.0 version just worked as expected. For now let's wait for further Hyprland development. :/