### PR TITLE
Allow own lang files

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,14 @@ Copy `/etc/nwg-hello/nwg-hello-default.css` to `/etc/nwg-hello/nwg-hello.css` an
 If you'd like to use own icons, do not replace `/usr/share/nwg-hello/*-default.svg` files. Place your `poweroff.svg`, 
 `reboot.svg` and `sleep.svg` files in the same directory.
 
+## Own language files
+
+You can't translate labels in the .glade file, as the program replaces the values with what's defined in 
+[language files](https://github.com/nwg-piotr/nwg-hello/tree/main/nwg_hello/langs). Since the 0.2.4 version, however, 
+you can copy your lang file to `/etc/nwg-hello/` and make desired changes there, 
+see https://github.com/nwg-piotr/nwg-hello/issues/19. Be careful with syntax, the JSON format is unforgiving.
+Test your lang file by running `nwg-hello -t -d` from terminal.
+
 ## Running on Debian and labwc
 
 Submitted by [@01micko](https://github.com/01micko).

--- a/nwg_hello/main.py
+++ b/nwg_hello/main.py
@@ -110,6 +110,9 @@ else:
 if os.path.isfile("/etc/nwg-hello/en_US"):
     # allow user-defined basic lang file in /etc/nwg-hello #19
     voc = load_json("/etc/nwg-hello/en_US")
+    if not voc:
+        eprint(f"Could not load /etc/nwg-hello/en_US, loading default file instead.")
+        voc = load_json(os.path.join(dir_name, "langs", "en_US"))
 else:
     # load predefined basic lang file
     voc = load_json(os.path.join(dir_name, "langs", "en_US"))
@@ -121,6 +124,9 @@ if user_locale != "en_US" and user_locale in os.listdir(os.path.join(dir_name, "
     if os.path.isfile(os.path.join("/etc/nwg-hello", user_locale)):
         # allow user-defined lang files in /etc/nwg-hello #19
         loc = load_json(os.path.join("/etc/nwg-hello", user_locale))
+        if not loc:
+            eprint(f"Could not load {os.path.join('/etc/nwg-hello', user_locale)}, loading default file instead.")
+            loc = load_json(os.path.join(dir_name, "langs", user_locale))
     else:
         # load predefined lang file
         loc = load_json(os.path.join(dir_name, "langs", user_locale))

--- a/nwg_hello/main.py
+++ b/nwg_hello/main.py
@@ -111,6 +111,7 @@ if os.path.isfile("/etc/nwg-hello/en_US"):
     # allow user-defined basic lang file in /etc/nwg-hello #19
     voc = load_json("/etc/nwg-hello/en_US")
     if not voc:
+        # couldn't load json!
         eprint(f"Could not load /etc/nwg-hello/en_US, loading default file instead.")
         voc = load_json(os.path.join(dir_name, "langs", "en_US"))
 else:
@@ -125,6 +126,7 @@ if user_locale != "en_US" and user_locale in os.listdir(os.path.join(dir_name, "
         # allow user-defined lang files in /etc/nwg-hello #19
         loc = load_json(os.path.join("/etc/nwg-hello", user_locale))
         if not loc:
+            # couldn't load json!
             eprint(f"Could not load {os.path.join('/etc/nwg-hello', user_locale)}, loading default file instead.")
             loc = load_json(os.path.join(dir_name, "langs", user_locale))
     else:

--- a/nwg_hello/main.py
+++ b/nwg_hello/main.py
@@ -107,12 +107,23 @@ else:
     client = None
 
 # Load vocabulary
-voc = load_json(os.path.join(dir_name, "langs", "en_US"))
+if os.path.isfile("/etc/nwg-hello/en_US"):
+    # allow user-defined basic lang file in /etc/nwg-hello #19
+    voc = load_json("/etc/nwg-hello/en_US")
+else:
+    # load predefined basic lang file
+    voc = load_json(os.path.join(dir_name, "langs", "en_US"))
+
 user_locale = locale.getlocale()[0] if not settings["lang"] else settings["lang"]
 # translate if necessary (and if we have a translation)
 if user_locale != "en_US" and user_locale in os.listdir(os.path.join(dir_name, "langs")):
     # translated phrases
-    loc = load_json(os.path.join(dir_name, "langs", user_locale))
+    if os.path.isfile(os.path.join("/etc/nwg-hello", user_locale)):
+        # allow user-defined lang files in /etc/nwg-hello #19
+        loc = load_json(os.path.join("/etc/nwg-hello", user_locale))
+    else:
+        # load predefined lang file
+        loc = load_json(os.path.join(dir_name, "langs", user_locale))
     for key in voc:
         if key in loc:
             voc[key] = loc[key]

--- a/nwg_hello/main.py
+++ b/nwg_hello/main.py
@@ -114,6 +114,9 @@ if os.path.isfile("/etc/nwg-hello/en_US"):
         # couldn't load json!
         eprint(f"Could not load /etc/nwg-hello/en_US, loading default file instead.")
         voc = load_json(os.path.join(dir_name, "langs", "en_US"))
+    else:
+        if args.debug:
+            eprint(f"Using /etc/nwg-hello/en_US lang file")
 else:
     # load predefined basic lang file
     voc = load_json(os.path.join(dir_name, "langs", "en_US"))
@@ -129,6 +132,9 @@ if user_locale != "en_US" and user_locale in os.listdir(os.path.join(dir_name, "
             # couldn't load json!
             eprint(f"Could not load {os.path.join('/etc/nwg-hello', user_locale)}, loading default file instead.")
             loc = load_json(os.path.join(dir_name, "langs", user_locale))
+        else:
+            if args.debug:
+                eprint(f"Using /etc/nwg-hello/{user_locale} lang file")
     else:
         # load predefined lang file
         loc = load_json(os.path.join(dir_name, "langs", user_locale))

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ def read(f_name):
 
 setup(
     name='nwg-hello',
-    version='0.2.3',
+    version='0.2.4',
     description='GTK3-based greeter for greetd',
     packages=find_packages(),
     include_package_data=True,


### PR DESCRIPTION
This PR allows to add user-modified lang files to `/etc/nwg-hello/`. If found, such a file will be used instead of a certain predefined lang file. Closes #19.