### PR TITLE
Update default CSS for vertical monitors

### DIFF
--- a/nwg-hello-default.css
+++ b/nwg-hello-default.css
@@ -1,5 +1,5 @@
 window {
-	background-image: url("/usr/share/nwg-hello/nwg.jpg"); background-size: 100% 100%
+	background-image: url("/usr/share/nwg-hello/nwg.jpg"); background-size: auto 100%
 }
 
 #form-wrapper {


### PR DESCRIPTION
This tiny change fixes an issue where vertical monitors (e.g. 9:16 aspect ratio) will have the background image squished horizontally, which looks a little odd. With this change, it will simply show the leftmost part of the background image and cut off the rightmost part for vertical monitors. Behavior is unchanged for standard horizontal monitors.