### PR TITLE
Update to start-hyprland

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ command = "agreety --cmd /bin/sh"
 with
 
 ```toml
-command = "Hyprland -c /etc/nwg-hello/hyprland.conf"
+command = "env HYPRLAND_CONFIG=/etc/nwg-hello/hyprland.conf start-hyprland"
 ```
 
 if you want to use Hyprland, or this line if you prefer sway:


### PR DESCRIPTION
As of Hyprland 0.53, the recommended way to launch has changed to `start-hyprland`. Launching with the old `Hyprland -c /etc/nwg-hello/hyprland.conf` method yields a small error message.

The easiest workaround I have found is to replace the greetd.conf command with the following:
```command = "env HYPRLAND_CONFIG=/etc/nwg-hello/hyprland.conf start-hyprland"```

Please consider updating the README accordingly, thanks!